### PR TITLE
Use splat syntax in firewall rule outputs to avoid warnings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "nomad_and_consul_servers" {
-  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.1"
+  source = "git::https://github.com/hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.2"
 
   gcp_zone = "${var.gcp_zone}"
 

--- a/modules/nomad-firewall-rules/outputs.tf
+++ b/modules/nomad-firewall-rules/outputs.tf
@@ -1,23 +1,23 @@
 output "firewall_rule_allow_inbound_http_url" {
-  value = "${google_compute_firewall.allow_inbound_http.self_link}"
+  value = "${google_compute_firewall.allow_inbound_http.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_http_id" {
-  value = "${google_compute_firewall.allow_inbound_http.id}"
+  value = "${google_compute_firewall.allow_inbound_http.*.id}"
 }
 
 output "firewall_rule_allow_inbound_rpc_url" {
-  value = "${google_compute_firewall.allow_inbound_rpc.self_link}"
+  value = "${google_compute_firewall.allow_inbound_rpc.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_rpc_id" {
-  value = "${google_compute_firewall.allow_inbound_rpc.id}"
+  value = "${google_compute_firewall.allow_inbound_rpc.*.id}"
 }
 
 output "firewall_rule_allow_inbound_serf_url" {
-  value = "${google_compute_firewall.allow_inbound_serf.self_link}"
+  value = "${google_compute_firewall.allow_inbound_serf.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_serf_id" {
-  value = "${google_compute_firewall.allow_inbound_serf.id}"
+  value = "${google_compute_firewall.allow_inbound_serf.*.id}"
 }


### PR DESCRIPTION
This is an small update to avoid warnings such as 

```
Warning: output "firewall_rule_inbound_dns_name": must use splat syntax to access google_compute_firewall.allow_inbound_dns attribute "name", because it has "count" set; use google_compute_firewall.allow_inbound_dns.*.name to obtain a list of the attributes across all instances
```

when using this module.

Note that in the interest of keeping the change to the module minimal I have only bumped the `terraform-google-consul` module version to `v.0.0.2` even though `v0.2.0` exists. 

# Testing

I have not done any specific testing beyond running `terraform validate` to ensure the warnings have gone away.

