### PR TITLE
WIP: Multi-zone deployment

### DIFF
--- a/examples/nomad-consul-image/nomad-consul.json
+++ b/examples/nomad-consul-image/nomad-consul.json
@@ -3,9 +3,9 @@
   "variables": {
     "project_id": null,
     "zone": null,
-    "nomad_version": "0.6.3",
-    "consul_module_version": "v0.0.1",
-    "consul_version": "0.9.3"
+    "nomad_version": "0.8.6",
+    "consul_module_version": "v0.2.0",
+    "consul_version": "1.2.3"
   },
   "builders": [{
     "type": "googlecompute",

--- a/examples/nomad-consul-separate-cluster/main.tf
+++ b/examples/nomad-consul-separate-cluster/main.tf
@@ -33,7 +33,7 @@ module "nomad_servers" {
   # source = "git::git@github.com:hashicorp/terraform-google-nomad.git//modules/nomad-cluster?ref=v0.0.1"
   source = "../../modules/nomad-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
 
   cluster_name = "${var.nomad_server_cluster_name}"
   cluster_size = "${var.nomad_server_cluster_size}"
@@ -72,9 +72,9 @@ data "template_file" "startup_script_nomad_server" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "consul_cluster" {
-  source = "git::git@github.com:gruntwork-io/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.2.0"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
   cluster_name = "${var.consul_server_cluster_name}"
   cluster_tag_name = "${var.consul_server_cluster_name}"
   cluster_size = "${var.consul_server_cluster_size}"
@@ -112,7 +112,7 @@ module "nomad_clients" {
   # source = "git::git@github.com:hashicorp/terraform-google-nomad.git//modules/nomad-cluster?ref=v0.0.1"
   source = "../../modules/nomad-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
 
   cluster_name = "${var.nomad_client_cluster_name}"
   cluster_size = "${var.nomad_client_cluster_size}"

--- a/examples/nomad-consul-separate-cluster/outputs.tf
+++ b/examples/nomad-consul-separate-cluster/outputs.tf
@@ -2,10 +2,6 @@ output "gcp_project" {
   value = "${var.gcp_project}"
 }
 
-output "gcp_zone" {
-  value = "${var.gcp_zone}"
-}
-
 output "nomad_server_cluster_size" {
   value = "${var.nomad_server_cluster_size}"
 }

--- a/examples/nomad-consul-separate-cluster/variables.tf
+++ b/examples/nomad-consul-separate-cluster/variables.tf
@@ -11,10 +11,6 @@ variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }
 
-variable "gcp_zone" {
-  description = "The region in which all GCP resources will be launched."
-}
-
 # Nomad Server cluster
 
 variable "nomad_server_cluster_name" {

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "nomad_and_consul_servers" {
-  source = "git::git@github.com:hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.1"
+  source = "git::https://github.com/hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.2"
 
   gcp_zone = "${var.gcp_zone}"
 

--- a/main.tf
+++ b/main.tf
@@ -29,9 +29,9 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 module "nomad_and_consul_servers" {
-  source = "git::https://github.com/hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.0.2"
+  source = "github.com/hashicorp/terraform-google-consul.git//modules/consul-cluster?ref=v0.2.0"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
 
   cluster_name = "${var.nomad_consul_server_cluster_name}"
   cluster_size = "${var.nomad_consul_server_cluster_size}"
@@ -58,7 +58,6 @@ module "nomad_and_consul_servers" {
 module "nomad_firewall_rules" {
   source = "modules/nomad-firewall-rules"
 
-  gcp_zone = "${var.gcp_zone}"
   cluster_name = "${var.nomad_consul_server_cluster_name}"
   cluster_tag_name = "${var.nomad_consul_server_cluster_name}"
 
@@ -89,7 +88,7 @@ module "nomad_clients" {
   # source = "git::git@github.com:hashicorp/terraform-google-nomad.git//modules/nomad-cluster?ref=v0.0.1"
   source = "modules/nomad-cluster"
 
-  gcp_zone = "${var.gcp_zone}"
+  gcp_region = "${var.gcp_region}"
 
   cluster_name = "${var.nomad_client_cluster_name}"
   cluster_size = "${var.nomad_client_cluster_size}"

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -10,18 +10,14 @@ terraform {
 
 # ---------------------------------------------------------------------------------------------------------------------
 # CREATE A GCE MANAGED INSTANCE GROUP TO RUN NOMAD
-# Ideally, we would run a "regional" Managed Instance Group that spans many Zones, but the Terraform GCP provider has
-# not yet implemented https://github.com/terraform-providers/terraform-provider-google/issues/45, so we settle for a
-# single-zone Managed Instance Group.
 # ---------------------------------------------------------------------------------------------------------------------
-
-# Create the single-zone Managed Instance Group where Nomad will run.
-resource "google_compute_instance_group_manager" "nomad" {
+# Create a regional Managed Instance Group where Nomad will run.
+resource "google_compute_region_instance_group_manager" "nomad" {
   name = "${var.cluster_name}-ig"
 
   base_instance_name = "${var.cluster_name}"
   instance_template  = "${data.template_file.compute_instance_template_self_link.rendered}"
-  zone               = "${var.gcp_zone}"
+  region               = "${var.gcp_region}"
 
   # Restarting all Nomad servers at the same time will result in data loss and down time. Therefore, the update strategy
   # used to roll out a new GCE Instance Template must be a rolling update. But since Terraform does not yet support
@@ -142,7 +138,6 @@ resource "google_compute_instance_template" "nomad_private" {
 module "firewall_rules" {
   source = "../nomad-firewall-rules"
 
-  gcp_zone = "${var.gcp_zone}"
   cluster_name = "${var.cluster_name}"
   cluster_tag_name = "${var.cluster_tag_name}"
 

--- a/modules/nomad-cluster/outputs.tf
+++ b/modules/nomad-cluster/outputs.tf
@@ -7,11 +7,11 @@ output "cluster_tag_name" {
 }
 
 output "instance_group_id" {
-  value = "${google_compute_instance_group_manager.nomad.id}"
+  value = "${google_compute_region_instance_group_manager.nomad.id}"
 }
 
 output "instance_group_url" {
-  value = "${google_compute_instance_group_manager.nomad.self_link}"
+  value = "${google_compute_region_instance_group_manager.nomad.self_link}"
 }
 
 output "instance_template_url" {

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -2,8 +2,7 @@
 # REQUIRED PARAMETERS
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
-
-variable "gcp_zone" {
+variable "gcp_region" {
   description = "All GCP resources will be launched in this Zone."
 }
 

--- a/modules/nomad-firewall-rules/outputs.tf
+++ b/modules/nomad-firewall-rules/outputs.tf
@@ -1,23 +1,23 @@
 output "firewall_rule_allow_inbound_http_url" {
-  value = "${google_compute_firewall.allow_inbound_http.self_link}"
+  value = "${google_compute_firewall.allow_inbound_http.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_http_id" {
-  value = "${google_compute_firewall.allow_inbound_http.id}"
+  value = "${google_compute_firewall.allow_inbound_http.*.id}"
 }
 
 output "firewall_rule_allow_inbound_rpc_url" {
-  value = "${google_compute_firewall.allow_inbound_rpc.self_link}"
+  value = "${google_compute_firewall.allow_inbound_rpc.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_rpc_id" {
-  value = "${google_compute_firewall.allow_inbound_rpc.id}"
+  value = "${google_compute_firewall.allow_inbound_rpc.*.id}"
 }
 
 output "firewall_rule_allow_inbound_serf_url" {
-  value = "${google_compute_firewall.allow_inbound_serf.self_link}"
+  value = "${google_compute_firewall.allow_inbound_serf.*.self_link}"
 }
 
 output "firewall_rule_allow_inbound_serf_id" {
-  value = "${google_compute_firewall.allow_inbound_serf.id}"
+  value = "${google_compute_firewall.allow_inbound_serf.*.id}"
 }

--- a/modules/nomad-firewall-rules/variables.tf
+++ b/modules/nomad-firewall-rules/variables.tf
@@ -2,11 +2,6 @@
 # REQUIRED PARAMETERS
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
-
-variable "gcp_zone" {
-  description = "All GCP resources will be launched in this Zone."
-}
-
 variable "cluster_name" {
   description = "The name of the Nomad cluster (e.g. nomad-stage). This variable is used to namespace all resources created by this module."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,10 +2,6 @@ output "gcp_project" {
   value = "${var.gcp_project}"
 }
 
-output "gcp_zone" {
-  value = "${var.gcp_zone}"
-}
-
 output "nomad_server_cluster_size" {
   value = "${var.nomad_consul_server_cluster_size}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,6 @@ variable "gcp_region" {
   description = "The region in which all GCP resources will be launched."
 }
 
-variable "gcp_zone" {
-  description = "The region in which all GCP resources will be launched."
-}
-
 # Nomad Server cluster
 
 variable "nomad_consul_server_cluster_name" {


### PR DESCRIPTION
This MR switches the module to deploying nomad clients and nomad/consul servers multi-zone, using a regional instance group manager instead of a single-zone one. 

This PR builds on #6 which should be merged first.

I've marked it as WIP as I've not yet validated all the parts - but I'd like feedback already, hence the PR.

## What I've done 

As part of this:

* Bumped the default version of the consul_module_version to `0.2.0` (as this is the version that supports being deployed regionally)
* Bumped default Nomad/Consul versions in the packer template to the latest versions
* removed the `gcp_zone` input/output as it's no longer used

## Testing 

Minimal - ran `terraform validate` and tested the code in my own (more heavily modified) fork of the module.
