### PR TITLE
Add app version for Region Instance Group Manager

### DIFF
--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -16,7 +16,9 @@ resource "google_compute_region_instance_group_manager" "nomad" {
   name = "${var.cluster_name}-ig"
 
   base_instance_name = var.cluster_name
-  instance_template  = data.template_file.compute_instance_template_self_link.rendered
+  version {
+    instance_template = data.template_file.compute_instance_template_self_link.rendered
+  }
   region               = var.gcp_region
 
   # Restarting all Nomad servers at the same time will result in data loss and down time. Therefore, the update strategy


### PR DESCRIPTION
Fixes the following error during tf plan

```
Error: "instance_template": this field cannot be set

  on .terraform/modules/nomad_clients/terraform-google-nomad-0.1.1/modules/nomad-cluster/main.tf line 15, in resource "google_compute_region_instance_group_manager" "nomad":
  15: resource "google_compute_region_instance_group_manager" "nomad" {



Error: "version": required field is not set

  on .terraform/modules/nomad_clients/terraform-google-nomad-0.1.1/modules/nomad-cluster/main.tf line 15, in resource "google_compute_region_instance_group_manager" "nomad":
  15: resource "google_compute_region_instance_group_manager" "nomad" {
```