### PR TITLE
Remove AWLCI from installer

### DIFF
--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -95,7 +95,7 @@ function install_dependencies {
 
   if $(has_apt_get); then
     sudo apt-get update -y
-    sudo apt-get install -y awscli curl unzip jq
+    sudo apt-get install -y curl unzip jq
     install_supervisord_debian
   else
     log_error "Could not find apt-get. Cannot install dependencies on this OS."


### PR DESCRIPTION
Removing the installation of awscli during the dependencies installation.

Fixing Issue #17 